### PR TITLE
Add more PHP packages

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -49,3 +49,32 @@ config:
     - php-pear
     - php5-curl
     - php5-imagick
+    - php5-cgi
+    - php5-common
+    - php5-dbg
+    - php5-enchant
+    - php5-fpm
+    - php5-gd
+    - php5-geoip
+    - php5-gmp
+    - php5-imap
+    - php5-interbase
+    - php5-intl
+    - php5-ldap
+    - php5-mapscript
+    - php5-mbstring
+    - php5-mcrypt
+    - php5-memcache
+    - php5-memcached
+    - php5-odbc
+    - php5-pspell
+    - php5-readline
+    - php5-recode
+    - php5-snmp
+    - php5-sqlite
+    - php5-svn
+    - php5-sybase
+    - php5-tidy
+    - php5-xcache
+    - php5-xmlrpc
+    - php5-xsl


### PR DESCRIPTION
So, I saw someone asked about this.
I take the packages from the PuPHPet list.

The list looks a bit weird with 4 lines of packages.
But maybe this can be fixed by better designers than me.

Also I was thinking on removing "php5-" and adding it in the option value html only or in the generated file.
What do you think about this? is there any package that does not start in php5?

Regards.
