### PR TITLE
Default docroot instead of placeholder

### DIFF
--- a/src/Phansible/Resources/views/index.html.twig
+++ b/src/Phansible/Resources/views/index.html.twig
@@ -89,7 +89,7 @@
                     <div class="field">
                         <label for="docroot">Document Root:</label>
                         <div class="ui left labeled input">
-                            <input type="text" id="docroot" name="docroot" placeholder="/vagrant" />
+                            <input type="text" id="docroot" name="docroot" value="/vagrant" />
                             <div class="ui corner label">
                                 <i class="icon asterisk"></i>
                             </div>


### PR DESCRIPTION
I just created a ansible playbook and it didn't work. I didn't enter the docroot because I thought it was already prefilled. But it was just a placeholder. 
