### PR TITLE
Selfupdate composer on Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
    - 5.5
 before_script:
+   - composer selfupdate
    - composer install --dev --no-interaction
    - php vendor/autoload.php
 script:


### PR DESCRIPTION
In order to ensure the latest version of composer on builds.

Example of one of the messages: https://travis-ci.org/Phansible/phansible/builds/20583317#L38
