### PR TITLE
Added PHP 5.6

### DIFF
--- a/src/Phansible/Resources/views/bundles/php.html.twig
+++ b/src/Phansible/Resources/views/bundles/php.html.twig
@@ -9,7 +9,8 @@
                 <label for="php_version">Version:</label>
                 <div class="three fluid ui buttons">
                     <input type="hidden" id="php_version" name="phpppa" value="php5" />
-                    <div class="ui green active button phpversion" data-value="php5">5.5</div>
+                    <div class="ui green active button phpversion" data-value="php5-5.6">5.6</div>
+                    <div class="ui black button phpversion" data-value="php5">5.5</div>
                     <div class="ui black button phpversion" data-value="php5-oldstable">5.4</div>
                 </div>
             </div>


### PR DESCRIPTION
PHP 5.6 is now available: https://launchpad.net/~ondrej/+archive/ubuntu/php5-5.6

Added this as the standard option of PHP version, so we push people forward.

Sorry, did not test it yet.
