### PR TITLE
Fixing Safari Downloads

### DIFF
--- a/src/Phansible/Controller/BundleController.php
+++ b/src/Phansible/Controller/BundleController.php
@@ -210,7 +210,8 @@ class BundleController extends Controller
 
         return $app->stream($stream, 200, array(
             'Content-length' => filesize($zipPath),
-            'Content-Disposition' => 'attachment; filename="phansible_' . $filename . '.zip"'
+            'Content-Disposition' => 'attachment; filename="phansible_' . $filename . '.zip"',
+            'Content-Type' => 'application/zip'
         ));
     }
 


### PR DESCRIPTION
Added a content-type header to the download action. Tried this out locally and
it stopped adding .html to the file and even extracted the zip into a folder.

This closes #55.

![screen shot 2014-09-05 at 12 53 59](https://cloud.githubusercontent.com/assets/94331/4164691/008d197c-34f9-11e4-9cdb-6dc5c5c17052.png)

Top example is the final result, and the previous ones are the broken ones.
