### PR TITLE
Switch from using shell: a2enmod to Ansible's 'apache2_module' in Apache role.

### DIFF
--- a/src/Phansible/Resources/ansible/roles/apache/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/apache/tasks/main.yml
@@ -4,7 +4,7 @@
   apt: pkg=apache2 state=latest
 
 - name: Install Apache Modules
-  shell: a2enmod {{ item }}
+  apache2_module: state=present name={{ item }}
   notify: restart apache
   with_items:
     - rewrite


### PR DESCRIPTION
This is a more Ansible-native way of doing things as per http://docs.ansible.com/apache2_module_module.html
