### PR TITLE
Fixing typo in webserver.html.twig

### DIFF
--- a/src/Phansible/Resources/views/bundles/webserver.html.twig
+++ b/src/Phansible/Resources/views/bundles/webserver.html.twig
@@ -31,7 +31,7 @@
             </div>
         </div>
         <div class="field">
-            <label for="servername">Server name: (space separeted)</label>
+            <label for="servername">Server name: (space separated)</label>
             <div class="ui left labeled input">
                 <input type="text" id="servername" name="servername" value="myApp.vb www.myApp.vb" />
             </div>


### PR DESCRIPTION
separeted => separated
