### PR TITLE
#81 - add button to disable databases

### DIFF
--- a/src/Phansible/Resources/views/bundles/database.html.twig
+++ b/src/Phansible/Resources/views/bundles/database.html.twig
@@ -5,17 +5,12 @@
     <div class="ui piled segment">
         <div class="ui top attached black label">Details</div>
         <div class="field">
-            <div class="three fluid ui buttons">
+            <div class="four fluid ui buttons">
 
                 {% set default_database = '' %}
-
+                <div class="ui green active button database checked" data-value="0">Disabled</div>
                 {% for key,database in config.databases %}
-                    {% if database.checked is defined %}
-                        {% set default_database = key %}
-                        <div class="ui green active button database checked" data-value="{{ key }}">{{ database.name }}</div>
-                    {% else %}
-                        <div class="ui black button database" data-value="{{ key }}">{{ database.name }}</div>
-                    {% endif %}
+                   <div class="ui black button database" data-value="{{ key }}">{{ database.name }}</div>
                 {% endfor %}
 
                 <input type="hidden" id="dbserver" name="dbserver" value="{{ default_database }}" />


### PR DESCRIPTION
We should have an option to also disable databases, the way it is now we need to choose between one of the options. It's just a interface problem, the backend already handles that.

Maybe there's a better way to present the options, this was what I could do quickly here:

![screenshot from 2014-10-25 16 58 12](https://cloud.githubusercontent.com/assets/293241/4780083/778dc51e-5c57-11e4-8677-7c4699ae284a.png)
