### PR TITLE
Windows installer handles multiple versions of ubuntu

### DIFF
--- a/src/Phansible/Resources/ansible/windows.sh
+++ b/src/Phansible/Resources/ansible/windows.sh
@@ -8,8 +8,8 @@ sudo apt-get update
 
 # Decide on package to install for `add-apt-repository` command
 #
-# USE_COMMON=1 when using a distributino over 12.04
-# USE_COMMON== when using a distribution older or at 12.04
+# USE_COMMON=1 when using a distribution over 12.04
+# USE_COMMON=0 when using a distribution at 12.04 or older
 USE_COMMON=$(echo "$DISTRIB_RELEASE > 12.04" | bc)
 
 if [ "$USE_COMMON" -eq "1" ];


### PR DESCRIPTION
Hi!

I made some updates to the `windows.sh` installer.

> I'm using a similar script to install Ansible locally for my own environments. (I'm not on windows, but like the idea of the server having Ansible and provisioning itself :D ). 

Here are some things my script is doing that might be useful for the `windows.sh` script as well!

The `python-software-properties` package doesn't provide the `add-apt-repository` command on Ubuntu 12.10+ :frowning: Ubuntu 12.10+ has the `software-properties-common` package, which installs `add-apt-repository`. 

I've added a check to use the appropriate package based on the Ubuntu release.

I've also switched the PPA to use the official `ppa:ansible/ansible` repository (which I believe is currently more up to date than the `ppa:rquillo/ansible`!)

Commit message:

```
Windows installer handles multiple versions of ubuntu
- Checks Ubuntu Version
- Decides between software-properties-common and python-software-properties
- Uses official ppa:ansible/ansible
```

Let me know if you spot any issues or improvements needed (there's a 2nd windows.sh file which I have not updated, I believe it's for provisioning the test server to run Phansible?)
- Chris
