### PR TITLE
Fix duplicate permission lines

### DIFF
--- a/src/Phansible/Resources/ansible/roles/php5-fpm/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/php5-fpm/tasks/main.yml
@@ -4,13 +4,13 @@
 
 #Needed for PHP 5.4
 - name: Set permissions on socket - owner
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;listen.owner' line='listen.owner = www-data'"
+  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
 
 - name: Set permissions on socket - group
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;listen.group' line='listen.group = www-data'"
+  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
 
 - name: Set permissions on socket - mode
-  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;listen.mode' line='listen.mode = 0660'"
+  lineinfile: "dest=/etc/php5/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
   notify: restart php5-fpm
 
 - name: ensure timezone is set in fpm php.ini


### PR DESCRIPTION
Patterns like `^;listen.group` will only replace the default setting during the first provisioning. Future provisionings will keep appending permission lines at the end of the file, since the semi-colon of the regexp(`^;listen.group`) won't match any lines in the file.

Applies to `listen.owner = www-data`, `listen.group = www-data` and `listen.mode = 0660`
