### PR TITLE
Prevent calling github API in tests

### DIFF
--- a/src/Phansible/Controller/DefaultController.php
+++ b/src/Phansible/Controller/DefaultController.php
@@ -15,6 +15,11 @@ use DateTimeZone;
 class DefaultController extends Controller
 {
     /**
+     * @var Github\Client
+     */
+    private $githubClient;
+
+    /**
      * @return string
      */
     public function indexAction()
@@ -48,15 +53,31 @@ class DefaultController extends Controller
         ]);
     }
 
+    public function getGithubClient()
+    {
+        if (null === $this->githubClient) {
+            $this->githubClient = new Client(
+                new CachedHttpClient(
+                    ['cache_dir' => __DIR__ . '/../../../app/cache/github-api-cache']
+                )
+            );
+        }
+
+        return $this->githubClient;
+    }
+
+    public function setGithubClient(Client $client)
+    {
+        $this->githubClient = $client;
+        return $this;
+    }
+
     public function aboutAction()
     {
-        $client = new Client(
-            new CachedHttpClient(
-                ['cache_dir' => __DIR__ . '/../../../app/cache/github-api-cache']
-            )
-        );
+        $response = $this->getGithubClient()
+            ->getHttpClient()
+            ->get('repos/Phansible/phansible/stats/contributors');
 
-        $response = $client->getHttpClient()->get('repos/Phansible/phansible/stats/contributors');
         $contributors = ResponseMediator::getContent($response);
 
         return $this->render('about.html.twig', ['contributors' => $contributors]);

--- a/tests/src/Phansible/Controller/DefaultControllerTest.php
+++ b/tests/src/Phansible/Controller/DefaultControllerTest.php
@@ -71,7 +71,33 @@ class DefaultControllerTests extends \PHPUnit_Framework_TestCase
         $container['syspackages'] = [];
         $container['phppackages'] = [];
 
+        $httpResponse = $this->getMockBuilder('\Guzzle\Http\Message\Response')
+            ->setConstructorArgs([200])
+            ->getMock();
+
+        $httpClient = $this->getMockBuilder('\Github\HttpClient\CachedHttpClient')
+            ->setMethods(['get'])
+            ->getMock();
+
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->with(
+                $this->equalTo(
+                    'repos/Phansible/phansible/stats/contributors'
+                )
+            )
+            ->will($this->returnValue($httpResponse));
+
+        $client = $this->getMockBuilder('\Github\Client')
+            ->setMethods(['getHttpClient'])
+            ->getMock();
+
+        $client->expects($this->once())
+            ->method('getHttpClient')
+            ->will($this->returnValue($httpClient));
+
         $this->controller->setPimple($container);
+        $this->controller->setGithubClient($client);
         $this->controller->aboutAction();
     }
 
@@ -125,5 +151,25 @@ class DefaultControllerTests extends \PHPUnit_Framework_TestCase
         $this->controller->docsAction($doc);
 
         unlink($docFile->getPathname());
+    }
+
+    /**
+     * @covers \Phansible\Controller\DefaultController::getGithubClient
+     */
+    public function testShouldGetDefaultGithubClient()
+    {
+        $this->assertInstanceOf('\Github\Client', $this->controller->getGithubClient());
+    }
+
+    /**
+     * @covers \Phansible\Controller\DefaultController::getGithubClient
+     * @covers \Phansible\Controller\DefaultController::setGithubClient
+     */
+    public function testShouldSetAndGetGithubClient()
+    {
+        $client = $this->getMock('\Github\Client');
+
+        $this->controller->setGithubClient($client);
+        $this->assertSame($client, $this->controller->getGithubClient());
     }
 }


### PR DESCRIPTION
- Fix Github client (Isolate the API with mocks)

Issue #118
