### PR TITLE
Improve Footer on Small Screens

### DIFF
--- a/src/Phansible/Resources/views/partials/footer.html.twig
+++ b/src/Phansible/Resources/views/partials/footer.html.twig
@@ -1,7 +1,7 @@
 <footer>
     <div class="mainFooter">
         <div class="container">
-            <div class="ui grid" id="footer">
+            <div class="ui stackable five column grid" id="footer">
 
                 <div class="one wide column">
                     <i class="circular inverted big cloud gift icon"></i>


### PR DESCRIPTION
Footer will now stack once it hits the mobile breakpoint.  Fixes #106 

This does not fix other footer issues related to window resizing.

![](http://i.imgur.com/xdNYnet.png)
