### PR TITLE
Make the whole menu buttons clickable

### DIFF
--- a/src/Phansible/Resources/views/main.html.twig
+++ b/src/Phansible/Resources/views/main.html.twig
@@ -7,7 +7,7 @@
     <a href="https://github.com/Phansible/phansible"><img id="forkme" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
         <div class="ui fixed transparent inverted main menu">
             <div class="container">
-                <a href="/"<div class="title item">>Home</div></a>
+                <a href="/"><div class="title item">Home</div></a>
                 <a href="/about"><div class="title item">About</div></a>
                 <div class="ui dropdown item">
                     Documentation <i class="icon dropdown"></i>


### PR DESCRIPTION
This PR fixes issue #123 .

The menu div is now inside the anchor tag, which works fine and is valid HTML 5.

Reference: http://www.w3.org/TR/html5/text-level-semantics.html#the-a-element
