### PR TITLE
Added hostname to playbook. Fixes #112

### DIFF
--- a/src/Phansible/Controller/BundleController.php
+++ b/src/Phansible/Controller/BundleController.php
@@ -231,6 +231,7 @@ class BundleController extends Controller
         $playbook = new PlaybookRenderer();
         $playbook->addVar('web_server', $webServerKey);
         $playbook->addVar('servername', trim($request->get('servername')) . ' ' . $request->get('ipAddress'));
+        $playbook->addVar('hostname', 'php5server');
         $playbook->addRole('init');
         $playbook->addRole('php5-cli');
         $playbook->addVar('timezone', $request->get('timezone'));


### PR DESCRIPTION
This re-sets the variable Hostname in the playbook.yml file to a default php5server for use without Vagrant.
