### PR TITLE
making sure that the hostname is in lowercase otherwise mariadb breaks

### DIFF
--- a/src/Phansible/Renderer/VagrantfileRenderer.php
+++ b/src/Phansible/Renderer/VagrantfileRenderer.php
@@ -39,7 +39,7 @@ class VagrantfileRenderer extends TemplateRenderer
         $this->setTemplate('Vagrantfile.twig');
         $this->setFilePath('Vagrantfile');
 
-        $this->setName('Default');
+        $this->setName('default');
         $this->setMemory('512');
         $this->setBoxName('ubuntu/trusty64');
         $this->setBoxUrl('');
@@ -55,7 +55,7 @@ class VagrantfileRenderer extends TemplateRenderer
     public function getData()
     {
         return [
-            'vmName'        => $this->getName(),
+            'vmName'        => strtolower($this->getName()),
             'memory'        => $this->getMemory(),
             'boxUrl'        => $this->getBoxUrl(),
             'boxName'       => $this->getBoxName(),

--- a/src/Phansible/Resources/views/bundles/vagrant.html.twig
+++ b/src/Phansible/Resources/views/bundles/vagrant.html.twig
@@ -18,7 +18,7 @@
                 <div class="field">
                     <label for="name">Name:</label>
                     <div class="ui left labeled input">
-                        <input type="text" id="vmname" name="vmname" placeholder="Default" value="Default" />
+                        <input type="text" id="vmname" name="vmname" placeholder="default" value="default" />
                         <div class="ui corner label">
                             <i class="icon asterisk"></i>
                         </div>

--- a/tests/src/Phansible/Renderer/VagrantfileRendererTest.php
+++ b/tests/src/Phansible/Renderer/VagrantfileRendererTest.php
@@ -28,7 +28,7 @@ class VagrantfileRendererTest extends \PHPUnit_Framework_TestCase
     public function testLoadDefaults()
     {
         $this->assertEquals(512, $this->model->getMemory());
-        $this->assertEquals('Default', $this->model->getName());
+        $this->assertEquals('default', $this->model->getName());
         $this->assertEquals('ubuntu/trusty64', $this->model->getBoxName());
         $this->assertEquals('192.168.33.99', $this->model->getIpAddress());
         $this->assertEquals('./', $this->model->getSyncedFolder());


### PR DESCRIPTION
Apparently there is no reason to have upper-case in the first place as the dns records are case insensitive
