### PR TITLE
Remove anonymous mysql users

### DIFF
--- a/src/Phansible/Resources/ansible/roles/mysql/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/mysql/tasks/main.yml
@@ -18,5 +18,11 @@
 - name: mysql | Create databases
   mysql_db: name={{ mysql.database }} state=present login_user=root login_password={{ mysql.root_password }}
 
+- name: mysql | Ensure anonymous users are not in the database
+  mysql_user: name='' host={{ item }} state=absent
+  with_items:
+    - localhost
+    - "{{ hostname }}"
+
 - name: mysql | Create users
   mysql_user: name={{ mysql.user }} password={{ mysql.password }} priv={{ mysql.database }}.*:ALL state=present login_user=root login_password={{ mysql.root_password }}


### PR DESCRIPTION
Anonymous users are annoying as they will take precedence over named MySQL users

This is [referred to](http://dev.mysql.com/doc/refman//5.5/en/connection-access.html) in the [MySQL Manual](http://dev.mysql.com/doc/refman//5.5/en/connection-access.html) with:

> When multiple matches are possible, the server must determine which of them to use. It resolves this issue as follows:
> 
> Whenever the server reads the user table into memory, it sorts the rows.
> 
> When a client attempts to connect, the server looks through the rows in sorted order.
> 
> The server uses the first row that matches the client host name and user name.
> 
> The server uses sorting rules that order rows with the most-specific Host values first. Literal host names and IP addresses are the most specific. (The specificity of a literal IP address is not affected by whether it has a netmask, so 192.168.1.13 and 192.168.1.0/255.255.255.0 are considered equally specific.) The pattern '%' means “any host” and is least specific. The empty string '' also means “any host” but sorts after '%'. Rows with the same Host value are ordered with the most-specific User values first (a blank User value means “any user” and is least specific). For rows with equally-specific Host and User values, the order is indeterminate.
