### PR TITLE
SuppressWarnings for CouplingBetweenObjects in application.php 

### DIFF
--- a/src/Phansible/Application.php
+++ b/src/Phansible/Application.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @package Phansible
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class Application extends \Flint\Application
 {


### PR DESCRIPTION
SuppressWarnings for CouplingBetweenObjects in application.php  because we register a lot of new roles.
