### PR TITLE
Simplification of Php role setup

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -11,6 +11,7 @@ docs.path: "%root_dir%/src/Phansible/Resources/docs"
     - app/config/phansible/phppackages.yml
     - app/config/phansible/databases.yml
     - app/config/phansible/peclpackages.yml
+    - app/config/phansible/rolepackagemap.yml
 
 config:
   bundles:

--- a/app/config/phansible/rolepackagemap.yml
+++ b/app/config/phansible/rolepackagemap.yml
@@ -1,0 +1,7 @@
+rolepackagemap:
+  php:
+    mysql:   php5-mysql
+    mariadb: php5-mysql
+    pgsql:   php5-pgsql
+    sqlite:  php5-sqlite
+    mongodb: php5-mongo

--- a/src/Phansible/Roles/Php.php
+++ b/src/Phansible/Roles/Php.php
@@ -35,20 +35,12 @@ class Php extends BaseRole
         }
 
         $playbook = $vagrantBundle->getPlaybook();
-        if ($playbook->hasRole('mysql') || $playbook->hasRole('mariadb')) {
-            $this->addPhpPackage('php5-mysql', $requestVars);
-        }
+        $roleMap  = $this->getRolePackageMap();
 
-        if ($playbook->hasRole('pgsql')) {
-            $this->addPhpPackage('php5-pgsql', $requestVars);
-        }
-
-        if ($playbook->hasRole('sqlite')) {
-            $this->addPhpPackage('php5-sqlite', $requestVars);
-        }
-
-        if ($playbook->hasRole('mongodb')) {
-            $this->addPhpPackage('php5-mongo', $requestVars);
+        foreach ($roleMap as $role => $package) {
+            if ($playbook->hasRole($role)) {
+                $this->addPhpPackage($package, $requestVars);
+            }
         }
 
         parent::setup($requestVars, $vagrantBundle);
@@ -64,5 +56,17 @@ class Php extends BaseRole
         if (in_array($package, $requestVars[$this->getSlug()]['packages']) === false) {
             $requestVars[$this->getSlug()]['packages'][] = $package;
         }
+    }
+
+    /**
+     * @return array
+     */
+    private function getRolePackageMap()
+    {
+        if (!isset($this->app['rolepackagemap'][$this->getSlug()])) {
+            return [];
+        }
+
+        return $this->app['rolepackagemap'][$this->getSlug()];
     }
 }


### PR DESCRIPTION
It adds a map for role packages, which are required and need to be installed if they are common to two different roles.

Example:

    The role Php defines that the package `php5-mysql` needs to be installed if MySQL(or MariaDB) were selected for installation.

This started as a simplification of the _setup_ method in the Php role, since the Scrutinizer report shows that the complexity [got worst](https://scrutinizer-ci.com/g/Phansible/phansible/inspections/0ede1679-bf54-4018-a143-dbef4ac68656/code-structure/operation/Phansible%5CRoles%5CPhp%3A%3Asetup).

In the future, we can make this automatic for all roles, and include the process of adding packages in the BaseRole.