### PR TITLE
Add a default language of en_US.UTF-8

### DIFF
--- a/src/Phansible/Resources/ansible/roles/server/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/server/tasks/main.yml
@@ -25,3 +25,7 @@
   sudo: yes
   file: src=/usr/share/zoneinfo/{{server.timezone}} dest=/etc/localtime state=link force=yes backup=yes
 
+- name: Set default system language pack
+  shell: locale-gen en_US.UTF-8
+  sudo: yes
+


### PR DESCRIPTION
This prevents a huge warning message from popping up when you ssh into a provided box.

It'd be nice in the future to give the user the chance to select this from a dropdown on the website.