### PR TITLE
Fixed invalid url (was pointing to /about)

### DIFF
--- a/src/Phansible/Resources/views/partials/footer.html.twig
+++ b/src/Phansible/Resources/views/partials/footer.html.twig
@@ -33,7 +33,7 @@
 
                 <div class="four wide column">
                     <div class="ui list inverted">
-                        <a class="item" href="/about">
+                        <a class="item" href="{{ path('phansible_docs', {'doc': 'customize'}) }}">
                             <i class="right triangle icon"></i>
                             Customizing your Bundle
                         </a>


### PR DESCRIPTION
The link "Customizing your Bundle" in the footer was pointing to /about. Fixed this.