### PR TITLE
[1.0] Add hostname in the shell script for windows users

### DIFF
--- a/src/Phansible/Resources/ansible/templates/Vagrantfile.twig
+++ b/src/Phansible/Resources/ansible/templates/Vagrantfile.twig
@@ -62,7 +62,7 @@ Vagrant.configure("2") do |config|
             }
         end
     else
-        config.vm.provision :shell, path: "ansible/windows.sh"
+        config.vm.provision :shell, path: "ansible/windows.sh", args: ["{{ vmName }}"]
     end
 
     {% else %}

--- a/src/Phansible/Resources/ansible/windows.sh
+++ b/src/Phansible/Resources/ansible/windows.sh
@@ -28,4 +28,4 @@ sudo apt-get install -y ansible
 cp /vagrant/ansible/inventories/dev /etc/ansible/hosts -f
 chmod 666 /etc/ansible/hosts
 cat /vagrant/ansible/files/authorized_keys >> /home/vagrant/.ssh/authorized_keys
-sudo ansible-playbook /vagrant/ansible/playbook.yml --connection=local
+sudo ansible-playbook /vagrant/ansible/playbook.yml -e hostname=$1 --connection=local


### PR DESCRIPTION
Same as #170 but for 1.0 branch.

This fixes the problem in #112
Now users using windows.sh will have the hostname variable.