### PR TITLE
[1.0] HHVM: Use PPA only in Precise.

### DIFF
--- a/src/Phansible/Resources/ansible/roles/hhvm/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/hhvm/tasks/main.yml
@@ -2,13 +2,13 @@
 
 - name: Add PPA repo
   apt_repository: repo=ppa:mapnik/boost
-  when: dist == 'precise'
+  when: ansible_distribution_release == 'precise'
 
 - name: Add HHVM repo key
   shell: wget -O - http://dl.hhvm.com/conf/hhvm.gpg.key | sudo apt-key add -
 
 - name: Add HHVM repo
-  shell: echo deb http://dl.hhvm.com/ubuntu {{ dist }} main | sudo tee /etc/apt/sources.list.d/hhvm.list
+  shell: echo deb http://dl.hhvm.com/ubuntu {{ ansible_distribution_release }} main | sudo tee /etc/apt/sources.list.d/hhvm.list
 
 - name: Update apt
   apt: update_cache=yes


### PR DESCRIPTION
Use fact instead of custom variables.
Prevent PPA usage in trusty
Fix #161

`dist` is a custom var, for some reason does not work ...

Anyway, I used the fact because is more correct and now is working :)
I didn't removed the `dist` variable since 1.0 branch is only for hot-fixes.

I'll check master branch to confirm if the behaviour exists there.
