### PR TITLE
Add Composer and Xdebug roles if PHP role exist.

### DIFF
--- a/src/Phansible/BaseRole.php
+++ b/src/Phansible/BaseRole.php
@@ -84,7 +84,7 @@ abstract class BaseRole implements RoleInterface
          * If the configuration doesn't have a section for this role
          * or if it'say not to install return false.
          */
-        if (!is_array($config) || !array_key_exists('install', $config) || $config['install'] === 0) {
+        if (!is_array($config) || !array_key_exists('install', $config) || $config['install'] == 0) {
             return false;
         }
         return true;

--- a/src/Phansible/Roles/Composer.php
+++ b/src/Phansible/Roles/Composer.php
@@ -16,4 +16,19 @@ class Composer extends BaseRole
           'install' => 0,
         ];
     }
+
+    protected function installRole($requestVars)
+    {
+        return parent::installRole($requestVars) && $this->phpWillBeInstalled($requestVars);
+    }
+
+    private function phpWillBeInstalled($requestVars)
+    {
+        $config = $requestVars['php'];
+
+        if (!is_array($config) || !array_key_exists('install', $config) || $config['install'] == 0) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/Phansible/Roles/Xdebug.php
+++ b/src/Phansible/Roles/Xdebug.php
@@ -17,4 +17,19 @@ class Xdebug extends BaseRole
           'settings' => [],
         ];
     }
+
+    protected function installRole($requestVars)
+    {
+        return parent::installRole($requestVars) && $this->phpWillBeInstalled($requestVars);
+    }
+
+    private function phpWillBeInstalled($requestVars)
+    {
+        $config = $requestVars['php'];
+
+        if (!is_array($config) || !array_key_exists('install', $config) || $config['install'] == 0) {
+            return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
This PR is a workaround of #146

Does the same but feels les "hacky".

I don't like too much the `phpWillBeInstalled` method but I thing is better than hacking the `BaseRole` to fit this special case.

I think this is a better way for now.
Finally the PHP role was also modified in #146 but was fixed with a different approach in another PR.