### PR TITLE
Don't perform a composer update on deploy

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -21,9 +21,6 @@
     - name: Run Composer
       shell: /usr/local/bin/composer install --no-dev --no-progress chdir={{ project_root }}
 
-    - name: Run Composer update
-      shell: /usr/local/bin/composer update --no-progress chdir={{ project_root }}
-
     - name: Read ACLs for web_user
       sudo: yes
       shell: 'setfacl -Rn -m u:"{{ webserver_user }}":rX -m d:u:"{{ webserver_user }}":rX {{ project_root }}'


### PR DESCRIPTION
Update will retrieve new non-tested library versions.

We don't want that!