### PR TITLE
Fix duplicated `opcache.enable` after multiple provisionings

### DIFF
--- a/src/Phansible/Resources/ansible/roles/php/tasks/mod-php.yml
+++ b/src/Phansible/Resources/ansible/roles/php/tasks/mod-php.yml
@@ -6,5 +6,5 @@
 
 - name: enabling opcache
   lineinfile: dest=/etc/php5/apache2/php.ini
-              regexp=';opcache.enable=0'
+              regexp=';?opcache.enable=\d'
               line='opcache.enable=1'

--- a/src/Phansible/Resources/ansible/roles/php/tasks/php-cli.yml
+++ b/src/Phansible/Resources/ansible/roles/php/tasks/php-cli.yml
@@ -6,5 +6,5 @@
 
 - name: enabling opcache cli
   lineinfile: dest=/etc/php5/cli/php.ini
-              regexp=';opcache.enable_cli=0'
+              regexp=';?opcache.enable_cli=\d'
               line='opcache.enable_cli=1'

--- a/src/Phansible/Resources/ansible/roles/php/tasks/php-fpm.yml
+++ b/src/Phansible/Resources/ansible/roles/php/tasks/php-fpm.yml
@@ -15,5 +15,5 @@
               line='date.timezone = {{ server.timezone }}'
 - name: enabling opcache
   lineinfile: dest=/etc/php5/fpm/php.ini
-              regexp=';opcache.enable=0'
+              regexp=';?opcache.enable=\d'
               line='opcache.enable=1'


### PR DESCRIPTION
Once _opcache_ is enabled this regex will never match again, making _Ansible_ to keep adding the same line to the _ini_ file.

As specified in Ansible’s documentation: “… If specified regular expression has no matches, EOF will be used instead.”