### PR TITLE
apply xdebug settings

### DIFF
--- a/src/Phansible/Resources/ansible/roles/xdebug/defaults/main.yml
+++ b/src/Phansible/Resources/ansible/roles/xdebug/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
-xdebug:
-    settings: []
+xdebug_settings:
+    xdebug.remote_enable: 1
+    xdebug.remote_connect_back: 1
+    xdebug.max_nesting_level: 300

--- a/src/Phansible/Resources/ansible/roles/xdebug/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/xdebug/tasks/main.yml
@@ -2,3 +2,11 @@
 - name: Install xDebug
   sudo: yes
   apt: pkg=php5-xdebug state=latest
+
+- name: Apply xDebug settings
+  sudo: true
+  lineinfile: dest=/etc/php5/mods-available/xdebug.ini
+              regexp='^;?{{ item.key }}'
+              line='{{ item.key }}={{ item.value }}'
+  notify: restart php5-fpm
+  with_dict: xdebug.settings | default({})

--- a/src/Phansible/Resources/ansible/roles/xdebug/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/xdebug/tasks/main.yml
@@ -9,4 +9,4 @@
               regexp='^;?{{ item.key }}'
               line='{{ item.key }}={{ item.value }}'
   notify: restart php5-fpm
-  with_dict: xdebug.settings | default({})
+  with_dict: xdebug_settings | default({})

--- a/src/Phansible/Roles/Xdebug.php
+++ b/src/Phansible/Roles/Xdebug.php
@@ -3,9 +3,11 @@
 namespace Phansible\Roles;
 
 use Phansible\Role;
+use Phansible\RoleValuesTransformer;
+use Phansible\Model\VagrantBundle;
 use Phansible\RoleWithDependencies;
 
-class Xdebug implements Role, RoleWithDependencies
+class Xdebug implements Role, RoleWithDependencies, RoleValuesTransformer
 {
     public function getName()
     {
@@ -33,5 +35,18 @@ class Xdebug implements Role, RoleWithDependencies
           'install' => 0,
           'settings' => [],
         ];
+    }
+
+    public function transformValues(array $values, VagrantBundle $vagrantBundle)
+    {
+        if ($values['install'] == 1) {
+            $values['settings'] = [
+                'xdebug.remote_enable' => 1,
+                'xdebug.remote_connect_back' => 1,
+                'xdebug.max_nesting_level' => 300
+            ];
+        }
+
+        return $values;
     }
 }

--- a/src/Phansible/Roles/Xdebug.php
+++ b/src/Phansible/Roles/Xdebug.php
@@ -3,11 +3,9 @@
 namespace Phansible\Roles;
 
 use Phansible\Role;
-use Phansible\RoleValuesTransformer;
-use Phansible\Model\VagrantBundle;
 use Phansible\RoleWithDependencies;
 
-class Xdebug implements Role, RoleWithDependencies, RoleValuesTransformer
+class Xdebug implements Role, RoleWithDependencies
 {
     public function getName()
     {
@@ -32,21 +30,7 @@ class Xdebug implements Role, RoleWithDependencies, RoleValuesTransformer
     public function getInitialValues()
     {
         return [
-          'install' => 0,
-          'settings' => [],
+          'install' => 0
         ];
-    }
-
-    public function transformValues(array $values, VagrantBundle $vagrantBundle)
-    {
-        if ($values['install'] == 1) {
-            $values['settings'] = [
-                'xdebug.remote_enable' => 1,
-                'xdebug.remote_connect_back' => 1,
-                'xdebug.max_nesting_level' => 300
-            ];
-        }
-
-        return $values;
     }
 }


### PR DESCRIPTION
Small fix for #229: 
Xdebug settings will be applied as soon as provided in all.yml. As there is no text field in phansible gui to edit the xdebug settings right now, the relevant config values sub tree xdebug.settings will be filled with a default set that enables debugging in the vm as soon as xdebug is selected. 
