### PR TITLE
Redis Role: added dependencies (build-essential) and dist-clean

### DIFF
--- a/src/Phansible/Resources/ansible/roles/redis/tasks/main.yml
+++ b/src/Phansible/Resources/ansible/roles/redis/tasks/main.yml
@@ -16,6 +16,8 @@
   apt: pkg={{ item }} state=latest
   with_items:
     - make
+    - build-essential
+    - tcl8.5
 
 - name: Download
   get_url: >
@@ -28,6 +30,10 @@
     src=/tmp/redis-{{ redis_version }}.tar.gz
     dest=/tmp
     copy=no
+  when: not is_installed
+
+- name: Clear any previous failed attempts
+  command: make distclean chdir=/tmp/redis-{{ redis_version }}
   when: not is_installed
 
 - name: Compile


### PR DESCRIPTION
I had have this problem with the Redis role for the second time now. The package `build-essential` needs to be installed in order to compile Redis, and when it's missing and you get an error, it won't install anymore even after getting `build-essential` installed. You get an error like this each time you run the provisioning:

```
TASK: [redis | Compile] ******************************************************* 
failed: [128.199.38.37] => {"changed": true, "cmd": ["make", "-j5"], "delta": "0:00:01.254755", "end": "2015-10-03 13:10:04.075520", "rc": 2, "start": "2015-10-03 13:10:02.820765", "warnings": []}
stderr:     CC adlist.o
    CC ae.o
    CC anet.o
    CC dict.o
    CC redis.o
In file included from adlist.c:34:0:
zmalloc.h:50:31: fatal error: jemalloc/jemalloc.h: No such file or directory
 #include <jemalloc/jemalloc.h>
```

The fix is running a `make distclean` as explained in this answer on SE:  http://unix.stackexchange.com/a/180758

Worked fine for me!