### PR TITLE
Update windows.sh

### DIFF
--- a/src/Phansible/Resources/ansible/windows.sh
+++ b/src/Phansible/Resources/ansible/windows.sh
@@ -25,7 +25,7 @@ sudo apt-get update
 sudo apt-get install -y ansible
 
 # Setup Ansible for Local Use and Run
-cp /vagrant/ansible/inventories/dev /etc/ansible/hosts -f
-chmod 666 /etc/ansible/hosts
-cat /vagrant/ansible/files/authorized_keys >> /home/vagrant/.ssh/authorized_keys
+sudo cp -f --parents /vagrant/ansible/inventories/dev /etc/ansible/hosts
+sudo chmod 666 /etc/ansible/hosts
+sudo cat /vagrant/ansible/files/authorized_keys >> /home/vagrant/.ssh/authorized_keys
 sudo ansible-playbook /vagrant/ansible/playbook.yml -e hostname=$1 --connection=local


### PR DESCRIPTION
Non existing `/etc/ansible` folder and missing `sudo` caused this error:

```
ERROR: The file ansible/inventories/dev is marked as executable, but failed to execute correctly. If this is not supposed to be an executable script, correct this with `chmod -x ansible/inventories/dev`.
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
