### PR TITLE
Adds mountPoint variable to Vagrantfile

### DIFF
--- a/src/Phansible/Renderer/VagrantfileRenderer.php
+++ b/src/Phansible/Renderer/VagrantfileRenderer.php
@@ -25,6 +25,9 @@ class VagrantfileRenderer extends TemplateRenderer
     /** @var  string Synced Folder */
     protected $syncedFolder;
 
+    /** @var  string Mount Point */
+    protected $mountPoint;
+
     /** @var  string Synced Folder Type */
     protected $syncedType;
 
@@ -42,6 +45,7 @@ class VagrantfileRenderer extends TemplateRenderer
         $this->setBoxUrl('');
         $this->setIpAddress('192.168.33.99');
         $this->setSyncedFolder('./');
+        $this->setMountPoint('/vagrant');
         $this->setSyncedType('nfs');
     }
 
@@ -57,6 +61,7 @@ class VagrantfileRenderer extends TemplateRenderer
             'boxName' => $this->getBoxName(),
             'ipAddress' => $this->getIpAddress(),
             'syncedFolder' => $this->getSyncedFolder(),
+            'mountPoint' => $this->getMountPoint(),
             'syncedType' => $this->getSyncedType(),
         ];
     }
@@ -150,11 +155,27 @@ class VagrantfileRenderer extends TemplateRenderer
     }
 
     /**
+     * @param string $mountPoint
+     */
+    public function setMountPoint($mountPoint)
+    {
+        $this->mountPoint = $mountPoint;
+    }
+
+    /**
      * @return string
      */
     public function getSyncedFolder()
     {
         return $this->syncedFolder;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMountPoint()
+    {
+        return $this->mountPoint;
     }
 
     /**

--- a/src/Phansible/Resources/ansible/templates/vagrant_local.twig
+++ b/src/Phansible/Resources/ansible/templates/vagrant_local.twig
@@ -58,6 +58,6 @@ Vagrant.configure("2") do |config|
         config.vm.provision :shell, path: "ansible/windows.sh", args: ["{{ vmName }}"]
     end
 
-    config.vm.synced_folder "{{ syncedFolder }}", "/vagrant"{% if syncedType %}, type: "{{ syncedType }}"{% if syncedType == "rsync" %}, rsync__exclude: ".git/"{% endif %}{% endif %}
+    config.vm.synced_folder "{{ syncedFolder }}", "{{ mountPoint }}"{% if syncedType %}, type: "{{ syncedType }}"{% if syncedType == "rsync" %}, rsync__exclude: ".git/"{% endif %}{% endif %}
 
 end

--- a/src/Phansible/Resources/views/bundles/vagrant.html.twig
+++ b/src/Phansible/Resources/views/bundles/vagrant.html.twig
@@ -35,7 +35,7 @@
                     </div>
                 </div>
             </div>
-            <div class="two fields">
+            <div class="three fields">
                 <div class="field">
                     <label for="memory">Memory</label>
                     <div class="ui left labeled input">
@@ -46,9 +46,18 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label for="memory">Shared Folder</label>
+                    <label for="sharedFolder">Shared Folder</label>
                     <div class="ui left labeled input">
                         <input type="text" id="sharedFolder" name="vagrant_local[vm][sharedfolder]" placeholder="./" value="./" />
+                        <div class="ui corner label">
+                            <i class="icon asterisk"></i>
+                        </div>
+                    </div>
+                </div>
+                <div class="field">
+                    <label for="mountPoint">Mount Point</label>
+                    <div class="ui left labeled input">
+                        <input type="text" id="mountPoint" name="vagrant_local[vm][mountPoint]" placeholder="/vagrant" value="/vagrant" />
                         <div class="ui corner label">
                             <i class="icon asterisk"></i>
                         </div>

--- a/src/Phansible/Roles/VagrantLocal.php
+++ b/src/Phansible/Roles/VagrantLocal.php
@@ -64,6 +64,7 @@ class VagrantLocal implements Role, RoleValuesTransformer
         $vagrantfile->setMemory($config['vm']['memory']);
         $vagrantfile->setIpAddress($config['vm']['ip']);
         $vagrantfile->setSyncedFolder($config['vm']['sharedfolder']);
+        $vagrantfile->setMountPoint($config['vm']['mountPoint']);
         $vagrantfile->setSyncedType($config['vm']['syncType']);
 
         // Add box url when NOT using the vagrant cloud

--- a/tests/src/Phansible/Roles/VagrantLocalTest.php
+++ b/tests/src/Phansible/Roles/VagrantLocalTest.php
@@ -77,6 +77,7 @@ class VagrantLocalTest extends \PHPUnit_Framework_TestCase
                 'ip'                => '192.168.33.99',
                 'memory'            => '512',
                 'sharedfolder'      => './',
+                'mountPoint'        => '/vagrant',
                 'syncType'          => 'nfs'
             ]
         ];


### PR DESCRIPTION
The user is able to indicate a custom mount point to the synced folder, still having `/vagrant` as default

Tests updated as well.

Issued in #249 
