### PR TITLE
Update Vagrantfile to work with ansible 2.2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,5 +33,5 @@ Vagrant.configure("2") do |config|
         config.vm.provision :shell, path: "ansible/windows.sh"
     end
 
-    config.vm.synced_folder "./", "/vagrant", id: "vagrant-root", :nfs => true
+    config.vm.synced_folder '.', '/vagrant', :mount_options => ["dmode=777", "fmode=777"]
 end


### PR DESCRIPTION
Updates Vagrantfile to work with ansible 2.2.0 since it's having trouble with nfs definition.
- Tested on Debian 8 64bits and ansible 2.2.0 compiled from source
