### PR TITLE
Fix with items format

### DIFF
--- a/ansible/roles/init/tasks/main.yml
+++ b/ansible/roles/init/tasks/main.yml
@@ -24,4 +24,4 @@
 - name: Install Extra Packages
   become: yes
   apt: pkg={{ item }} state=latest
-  with_items: sys_packages
+  with_items: '{{ sys_packages }}'

--- a/ansible/roles/phpcommon/tasks/main.yml
+++ b/ansible/roles/phpcommon/tasks/main.yml
@@ -1,4 +1,4 @@
 - name: Install PHP Packages
   become: yes
   apt: pkg={{ item }} state=latest
-  with_items: php_packages
+  with_items: '{{ php_packages }}'


### PR DESCRIPTION
This includes the system packages & the php packages.

For some reason I can't find the pecl packages, and the roles look different to those returned by the Phansible build.  Have these been changed?  Happy to change the others if they still need doing, and someone can point me in the right direction.